### PR TITLE
Filter 'x-content-type-options' from twitter's response headers

### DIFF
--- a/proxy/index.js
+++ b/proxy/index.js
@@ -72,7 +72,7 @@ exports.proxyRequest = function (opts, cb) {
  * Filter out unwanted information from a headers object.
  */
 exports.filterHeaders = function (headers) {
-  var reject = ['content-length', 'content-type'];
+  var reject = ['content-length', 'content-type', 'x-content-type-options'];
   return Object.keys(headers).reduce(function (memo, key){
     if (!_.contains(reject, key)) {
       memo[key] = headers[key];


### PR DESCRIPTION
Twitter responds with `x-content-type-options` set to `nosniff` (rightfully so), unfortunately this leads to strict MIME errors when used in browsers (like we do with the twitterwall), so that the script is not executed:

![reject_js_2014](https://cloud.githubusercontent.com/assets/82050/4206140/ca0b022c-3847-11e4-8ab4-05e214797b75.png)

This just filters this out from the response headers.
